### PR TITLE
wizard verticale

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -8,12 +8,15 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: true
           fetch-depth: 0
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '10'
       - name: Install
         run: yarn install
       - name: Build

--- a/src/assets/scss/components/unibo/u_wizard.scss
+++ b/src/assets/scss/components/unibo/u_wizard.scss
@@ -1,14 +1,14 @@
 .u-wizard-path {
   margin: 2.5em 0;
   counter-reset: step;
-  
+
   li {
     list-style: none;
     position: relative;
     padding-bottom: 2em;
     padding-right: 2em;
     padding-left: 5em;
-    
+
     &:before {
       content: "";
       width: 1px;
@@ -21,27 +21,27 @@
     &:first-child {
       padding-left: 5em;
       font-weight: 600;
-      
-      a {
+
+      :first-child {
         color: $light-black;
-        
+
         &:before {
           color: currentColor;
         }
       }
-      &.current-step a {
+      &.current-step :first-child {
         color: $primary-color;
       }
     }
     &:last-child {
       font-weight: 600;
       padding-left: 5em;
-      
+
       &:before {
         display: none;
       }
     }
-    a {
+    :first-child {
       font-size: 1.15384615em;
       line-height: 19px;
       color: $light-black;
@@ -49,7 +49,7 @@
       margin-bottom: 0.5em;
       padding-top: 3px;
       text-decoration: none;
-      
+
       &:before {
         counter-increment: step;
         content: counter(step);
@@ -66,53 +66,53 @@
         padding: 2px;
       }
     }
-    p {
+    :last-child {
       margin-bottom: 0;
     }
   }
   .previous-step {
-    a {
+    :first-child {
       cursor: pointer;
-      
+
       &:before {
         color: $success-color;
       }
     }
-    &.warning-step a:before {
+    &.warning-step :first-child {
       color: $warning-color;
       content: "!";
     }
   }
   .final-step {
-    a {
+    :first-child {
       color: $medium-gray;
       display: block;
       color: $light-black;
-      
+
       &:before {
         color: inherit;
       }
     }
-    &.current-step a {
+    &.current-step :first-child {
       color: $primary-color;
-      
+
     }
   }
-  .current-step a {
+  .current-step :first-child {
     color: $medium-gray;
     display: block;
     font-weight: 600;
     color: $primary-color;
     display: block;
-    
+
     &:before {
       color: $primary-color;
     }
   }
-  .next-step a {
+  .next-step :first-child {
     color: $medium-gray;
     display: block;
-    
+
     &:before {
       content: "\f111";
       font-size: 8px;
@@ -121,21 +121,21 @@
       top: 5px;
     }
   }
-  
+
   // Horizontal flex Wizard
   &.horizontal {
     display: flex;
     justify-content: space-between;
     text-align: center;
     overflow-x: hidden;
-    
+
     li {
       padding: 35px 10px;
       width: 100%;
-      
+
       &:last-of-type {
         z-index: 1;
-        
+
         &:after {
           content: "";
           width: 50%;
@@ -153,9 +153,9 @@
         left: 50%;
         height: 1px;
       }
-      a {
+      :first-child {
         position: relative;
-        
+
         &:before {
           margin: 0 !important;
           top: -35px;
@@ -163,7 +163,7 @@
         }
         span {
           display: none;
-          
+
           @include breakpoint(medium){
             display: inline;
           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1481,12 +1481,12 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@0.21.1:
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
-  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+axios@0.21.1, axios@^0.21.2:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
-    follow-redirects "^1.10.0"
+    follow-redirects "^1.14.0"
 
 babel-loader@^8.0.4:
   version "8.2.2"
@@ -3769,10 +3769,15 @@ flush-write-stream@^1.0.0, flush-write-stream@^1.0.2:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@^1.0.0, follow-redirects@^1.10.0:
+follow-redirects@^1.0.0:
   version "1.13.3"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.3.tgz#e5598ad50174c1bc4e872301e82ac2cd97f90267"
   integrity sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==
+
+follow-redirects@^1.14.0:
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
+  integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
attualmente nel wizard verticale le regole di css sono agganciate ai tag `a` e `p`, questo rende obbligatorio usare un `a` per il titolo (con potenziali problemi di accessibilità se non ha una href), non rende possibile mettere un'eventuale secondo `a` nel contenuto.

idealmente forse sarebbe meglio usare delle classi, la proposta qui serve a evitare la breaking change e dovrebbe lasciare funzionanti le componenti esistenti.